### PR TITLE
Add Vitest test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "serve": "vite preview",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist -r git@github.com:lvjian700/ihahits.git"
+    "deploy": "gh-pages -d dist -r git@github.com:lvjian700/ihahits.git",
+    "test": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -31,6 +32,7 @@
     "postcss": "^8.4.22",
     "tailwindcss": "^3.3.2",
     "typescript": "^5.0.4",
-    "vite": "^4.3.9"
+    "vite": "^4.3.9",
+    "vitest": "^0.34.6"
   }
 }

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { getLocalDateString } from './date';
+
+describe('getLocalDateString', () => {
+  it('formats January 5 as 2023-01-05', () => {
+    const date = new Date(2023, 0, 5);
+    expect(getLocalDateString(date)).toBe('2023-01-05');
+  });
+});


### PR DESCRIPTION
## Summary
- add `vitest` dev dependency and `test` script
- create a unit test for `getLocalDateString`

## Testing
- `npm test` *(fails: sh: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684694b6fdd08324b764a51a14258fc4