### PR TITLE
Use custom Tailwind color for app background

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
     <title>2-Minute Habits</title>
   </head>
-  <body>
+  <body class="bg-color-background">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
     <script>

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,6 @@
 /* Global base styles */
 @layer base {
   html, body {
-    background-color: #FCF7EE;
     font-family: 'Inter var', ui-sans-serif, system-ui, sans-serif;
     font-size: 16px;
     color: #4A5568;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -7,7 +7,8 @@ module.exports = {
         'color-title': '#1E3A5F',
         'color-subtitle': '#2D4A6D',
         'color-text': '#4A5568',
-        'color-text-light': '#718096'
+        'color-text-light': '#718096',
+        'color-background': '#FCF7EE'
       },
       fontFamily: {
         sans: ['Inter var', 'ui-sans-serif', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
## Summary
- add `color-background` to Tailwind colors
- remove hardcoded background-color from `src/index.css`
- apply `bg-color-background` class on the `<body>` element

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c2f978e088324b0a596f94eaf9740