### PR TITLE
Refactor click-outside hook

### DIFF
--- a/src/components/AppMenu.tsx
+++ b/src/components/AppMenu.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import { Menu as MenuIcon, Trash2, Laptop, type LucideIcon, Plus, RefreshCcwDot } from 'lucide-react';
 import { exportHabitsToFile, importHabitsFromFile } from '../utils/appData';
 import useHabits from '../hooks/useHabits';
+import useClickOutside from '../hooks/useClickOutside';
 
 
 interface AppMenuProps {
@@ -33,24 +34,7 @@ const AppMenu: React.FC<AppMenuProps> = ({ setSelectedHabitId }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const closeMenu = () => setIsMenuOpen(false);
   const menuRef = useRef<HTMLDivElement>(null);
-
-  // Close menu when clicking outside
-  useEffect(() => {
-    if (!isMenuOpen) return;
-
-    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        closeMenu();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('touchstart', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('touchstart', handleClickOutside);
-    };
-  }, [isMenuOpen]);
+  useClickOutside(menuRef, closeMenu, { active: isMenuOpen });
 
 
   // Clear all habit data

--- a/src/components/EmojiPickerPopover.tsx
+++ b/src/components/EmojiPickerPopover.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import Picker from '@emoji-mart/react';
 import data from '@emoji-mart/data';
 import type { EmojiData } from '../types/EmojiData';
+import useClickOutside from '../hooks/useClickOutside';
 
 interface EmojiPickerPopoverProps {
   anchorRef: React.RefObject<HTMLDivElement>;
@@ -26,23 +27,7 @@ const EmojiPickerPopover: React.FC<EmojiPickerPopoverProps> = ({ anchorRef, isOp
     }
   }, [isOpen, anchorRef]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleOutside = (event: MouseEvent) => {
-      if (
-        pickerRef.current &&
-        !pickerRef.current.contains(event.target as Node) &&
-        anchorRef.current &&
-        !anchorRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
-    document.addEventListener('mousedown', handleOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleOutside);
-    };
-  }, [isOpen, onClose, anchorRef]);
+  useClickOutside(pickerRef, onClose, { active: isOpen, ignoreRefs: [anchorRef] });
 
   if (!isOpen) return null;
 
@@ -57,7 +42,7 @@ const EmojiPickerPopover: React.FC<EmojiPickerPopoverProps> = ({ anchorRef, isOp
         pointerEvents: visible ? 'auto' : 'none',
       }}
     >
-      <Picker data={data} onEmojiSelect={(emoji) => onSelect(emoji as EmojiData)} theme="light" />
+      <Picker data={data} onEmojiSelect={(emoji: EmojiData) => onSelect(emoji)} theme="light" />
     </div>,
     document.body
   );

--- a/src/components/HabitDetailsView.tsx
+++ b/src/components/HabitDetailsView.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import useClickOutside from '../hooks/useClickOutside';
 import ReactDOM from 'react-dom';
 import type { Habit } from '../types/Habit';
 import { Archive, MoreHorizontal, X } from 'lucide-react';
@@ -41,26 +42,7 @@ const DropdownMenu: React.FC<{
     }
   }, [isOpen, buttonRef]);
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        menuRef.current &&
-        !menuRef.current.contains(event.target as Node) &&
-        buttonRef.current &&
-        !buttonRef.current.contains(event.target as Node)
-      ) {
-        onClose();
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isOpen, onClose, buttonRef]);
+  useClickOutside(menuRef, onClose, { active: isOpen, ignoreRefs: [buttonRef] });
 
   if (!isOpen) return null;
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,12 +1,22 @@
 import React, { useEffect, useRef } from 'react';
 
+import useClickOutside from '../hooks/useClickOutside';
+
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
+  dialogClassName?: string;
+  closeOnOutsideClick?: boolean;
 }
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  children,
+  dialogClassName,
+  closeOnOutsideClick = true,
+}) => {
   const modalRef = useRef<HTMLDivElement>(null);
 
   // Close on escape key press
@@ -29,23 +39,17 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
     };
   }, [isOpen, onClose]);
 
-  // Close when clicking outside the modal
-  const handleOutsideClick = (e: React.MouseEvent) => {
-    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-      onClose();
-    }
-  };
+  useClickOutside(modalRef, onClose, { active: isOpen && closeOnOutsideClick });
 
   if (!isOpen) return null;
 
   return (
     <div 
       className="fixed inset-0 z-50 flex items-start justify-center pt-16 p-4 bg-black bg-opacity-50 transition-opacity"
-      onClick={handleOutsideClick}
     >
-      <div 
+      <div
         ref={modalRef}
-        className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] overflow-auto transform transition-all"
+        className={`bg-white rounded-xl shadow-xl w-full max-h-[90vh] overflow-auto transform transition-all ${dialogClassName ?? 'max-w-2xl'}`}
         onClick={e => e.stopPropagation()}
       >
         {children}

--- a/src/components/SetupModal.tsx
+++ b/src/components/SetupModal.tsx
@@ -1,32 +1,6 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import type { Habit } from '../types/Habit';
-
-// Custom modal wrapper with appropriate width for setup
-const SetupModalWrapper: React.FC<{children: React.ReactNode}> = ({ children }) => {
-  const modalRef = useRef<HTMLDivElement>(null);
-  
-  // Handle click outside to close (not used but kept for future functionality)
-  const handleOutsideClick = (e: React.MouseEvent) => {
-    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-      // No-op for now, since we don't want to close the setup modal
-    }
-  };
-
-  return (
-    <div 
-      className="fixed inset-0 z-50 flex items-start justify-center pt-16 p-4 bg-black bg-opacity-50 transition-opacity"
-      onClick={handleOutsideClick}
-    >
-      <div 
-        ref={modalRef}
-        className="bg-white rounded-xl shadow-xl w-full max-w-md max-h-[90vh] overflow-auto transform transition-all"
-        onClick={e => e.stopPropagation()}
-      >
-        {children}
-      </div>
-    </div>
-  );
-};
+import Modal from './Modal';
 
 interface Suggestion {
   name: string;
@@ -93,7 +67,7 @@ const SetupModal: React.FC<SetupModalProps> = ({ suggestions, maxSelectable, def
   };
 
   return (
-    <SetupModalWrapper>
+    <Modal isOpen={true} onClose={() => {}} closeOnOutsideClick={false} dialogClassName="max-w-md">
       <div className="p-6">
         <h2 className="text-2xl font-semibold mb-4 text-gray-800">
           Choose up to {maxSelectable} Habits
@@ -150,7 +124,7 @@ const SetupModal: React.FC<SetupModalProps> = ({ suggestions, maxSelectable, def
           </button>
         </div>
       </div>
-    </SetupModalWrapper>
+    </Modal>
   );
 };
 

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,31 @@
+import { RefObject, useEffect } from 'react';
+
+export interface ClickOutsideOptions {
+  active?: boolean;
+  ignoreRefs?: RefObject<HTMLElement>[];
+}
+
+export default function useClickOutside(
+  ref: RefObject<HTMLElement>,
+  handler: () => void,
+  { active = true, ignoreRefs = [] }: ClickOutsideOptions = {}
+) {
+  useEffect(() => {
+    if (!active) return;
+
+    const listener = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node;
+      if (!ref.current || ref.current.contains(target)) return;
+      if (ignoreRefs.some(r => r.current && r.current.contains(target))) return;
+      handler();
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler, active, ignoreRefs]);
+}


### PR DESCRIPTION
## Summary
- refine `useClickOutside` options API
- type emoji select handler correctly
- adjust components for new hook signature

## Testing
- `npx tsc --noEmit`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68554dcbb4fc832487132e844e9e2553