### PR TITLE
Fix archive and clear data actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,8 @@ const App: React.FC = () => {
   useVisibilityRefresh();
 
   const {
+    store,
+    setStore,
     habits,
     activeHabits,
     archivedHabits,
@@ -42,13 +44,15 @@ const App: React.FC = () => {
       <div className="min-h-screen p-4">
       <div className="relative max-w-4xl mx-auto">
       <h1 className="text-title-lg mb-6 text-color-title text-center">2-Minute Habits</h1>
-      {habits.length > 0 && (
-        <AppMenu 
-          setSelectedHabitId={setSelectedHabitId}
-          addNewHabits={addNewHabits}
-          activeHabitsCount={activeHabits.length}
-        />
-      )}
+        {habits.length > 0 && (
+          <AppMenu
+            setSelectedHabitId={setSelectedHabitId}
+            addNewHabits={addNewHabits}
+            activeHabitsCount={activeHabits.length}
+            habits={store}
+            setStore={setStore}
+          />
+        )}
       </div>
       {habits.length === 0 && (
         <SetupModal

--- a/src/components/AppMenu.tsx
+++ b/src/components/AppMenu.tsx
@@ -1,14 +1,17 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Trash2, Laptop, type LucideIcon, RefreshCcwDot, Plus, MoreHorizontal } from 'lucide-react';
 import { exportHabitsToFile, importHabitsFromFile } from '../utils/appData';
-import type { Habit } from '../types/Habit';
-import useHabits from '../hooks/useHabits';
+import type { Habit, HabitStore } from '../types/Habit';
+// State is passed in from the parent component to avoid creating a second habit store
+// so we no longer import and call the useHabits hook here
 import useClickOutside from '../hooks/useClickOutside';
 
 interface AppMenuProps {
   setSelectedHabitId: (id: number | null) => void;
   addNewHabits: (newHabits: Omit<Habit, 'logs'>[]) => void;
   activeHabitsCount: number;
+  habits: HabitStore;
+  setStore: React.Dispatch<React.SetStateAction<HabitStore>>;
 }
 
 interface MenuItemProps {
@@ -60,8 +63,13 @@ const MoreButton: React.FC<MoreButtonProps> = ({ isOpen, toggle }) => (
   </button>
 );
 
-const AppMenu: React.FC<AppMenuProps> = ({ setSelectedHabitId, addNewHabits, activeHabitsCount }) => {
-  const { store: habits, setStore } = useHabits();
+const AppMenu: React.FC<AppMenuProps> = ({
+  setSelectedHabitId,
+  addNewHabits,
+  activeHabitsCount,
+  habits,
+  setStore,
+}) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isNewHabitOpen, setIsNewHabitOpen] = useState(false);
   const newHabitRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary
- keep a single habit store instance by passing store and setStore to `AppMenu`
- update `AppMenu` props and logic accordingly

## Testing
- `npm run build`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859490134ac8324acf2d76c3bbf1d82