### PR TITLE
Refactor grid to use context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { getLocalDateString } from './utils/date';
 import HabitsDndGrid from './components/HabitsDndGrid';
-import { useHabitsContext } from './context/HabitsContext';
 import HabitDetailsView from './components/HabitDetailsView';
 import Modal from './components/Modal';
 import AppMenu from './components/AppMenu';
@@ -11,12 +9,6 @@ const App: React.FC = () => {
   // Handle app initialization, service worker updates, and date refresh
   useBoot();
 
-  const {
-    habits,
-    activeHabits,
-    setActiveHabits,
-    toggleLog,
-  } = useHabitsContext();
   const [selectedHabitId, setSelectedHabitId] = useState<number | null>(null);
 
   return (
@@ -29,28 +21,7 @@ const App: React.FC = () => {
           />
           
           {/* Grid view of habits */}
-          <HabitsDndGrid
-              habits={activeHabits}
-              onReorder={newActive => {
-                // Maintain order only within active habits
-                const newOrderIds = newActive.map(h => h.id);
-                const reordered = [...habits].sort((a,b)=>{
-                  const ai = newOrderIds.indexOf(a.id);
-                  const bi = newOrderIds.indexOf(b.id);
-                  if(ai===-1) return 1; // archived stay at bottom
-                  if(bi===-1) return -1;
-                  return ai - bi;
-                });
-                setActiveHabits(reordered);
-              }}
-              onToggle={(habitId) =>
-                toggleLog(
-                  habitId,
-                  getLocalDateString()
-                )
-              }
-              onSelect={setSelectedHabitId}
-            />
+          <HabitsDndGrid onSelect={setSelectedHabitId} />
             
             {/* Modal with habit details */}
             <Modal 

--- a/src/components/HabitsDndGrid.tsx
+++ b/src/components/HabitsDndGrid.tsx
@@ -3,12 +3,11 @@ import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from 
 import { arrayMove, SortableContext, useSortable, rectSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import HabitCard from './HabitCard';
+import { getLocalDateString } from '../utils/date';
+import { useHabitsContext } from '../context/HabitsContext';
 import type { Habit } from '../types/Habit';
 
 interface HabitsDndGridProps {
-  habits: Habit[];
-  onReorder: (newHabits: Habit[]) => void;
-  onToggle: (habitId: number) => void;
   onSelect: (habitId: number) => void;
 }
 
@@ -50,7 +49,10 @@ function SortableHabitCard({ habit, idx, onToggle, onSelect }: SortableHabitCard
   );
 }
 
-const HabitsDndGrid: React.FC<HabitsDndGridProps> = ({ habits, onReorder, onToggle, onSelect }) => {
+const HabitsDndGrid: React.FC<HabitsDndGridProps> = ({ onSelect }) => {
+  const { activeHabits, setActiveHabits, toggleLog } = useHabitsContext();
+  const habits = activeHabits;
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 1 } })
   );
@@ -60,7 +62,7 @@ const HabitsDndGrid: React.FC<HabitsDndGridProps> = ({ habits, onReorder, onTogg
     if (active.id !== over?.id) {
       const oldIndex = habits.findIndex(h => h.id === active.id);
       const newIndex = habits.findIndex(h => h.id === over.id);
-      onReorder(arrayMove(habits, oldIndex, newIndex));
+      setActiveHabits(arrayMove(habits, oldIndex, newIndex));
     }
   };
 
@@ -74,7 +76,7 @@ const HabitsDndGrid: React.FC<HabitsDndGridProps> = ({ habits, onReorder, onTogg
               key={habit.id}
               habit={habit}
               idx={idx}
-              onToggle={onToggle}
+              onToggle={(id) => toggleLog(id, getLocalDateString())}
               onSelect={onSelect}
             />
           ))}


### PR DESCRIPTION
## Summary
- simplify `HabitsDndGrid` by consuming `HabitsContext`
- update `App` to pass only `onSelect`

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_687359267a808324b4bd0ae99ff68a5c